### PR TITLE
Add support for multiple tokens

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -23,7 +23,7 @@ Here's how to start:
 
 3. **Run the integration with Docker**  
   Back on your server, you only need to run your container, with some environnement variables
-    - `MATTERMOST_GIPHY_TOKEN=<your-token-here>` : this is the token you copied in the last section
+    - `MATTERMOST_GIPHY_TOKEN=<your-token-here>` : this is the token you copied in the last section (you can specify multiple tokens which are separated by a colon)
     - `MATTERMOST_GIPHY_HOST=<your-host>`  : the host you want the integration (defaults to 0.0.0.0)
     - `MATTERMOST_GIPHY_PORT=<your-port-number>` : the port number you want the integration to listen on (defaults to 5000)
     - `GIPHY_API_KEY=<giphy-api-key>` : key to use for Giphy API. Default public one is `dc6zaTOxFJmzC`

--- a/LINUX.md
+++ b/LINUX.md
@@ -29,7 +29,7 @@ Here's how to start:
 
 3. **Run the server with the correct configuration**
  1. Back on SSH or your terminal, add the following lines to your `~/.bash_profile`
-    - `export MATTERMOST_GIPHY_TOKEN=<your-token-here>` This is the token you copied in the last section
+    - `export MATTERMOST_GIPHY_TOKEN=<your-token-here>` This is the token you copied in the last section (you can specify multiple tokens which are separated by a colon)
     - `export MATTERMOST_GIPHY_HOST=<your-host>` or `export HOST=<your-host>` The host you want the integration (defaults to 0.0.0.0)
     - `export MATTERMOST_GIPHY_PORT=<your-port-number>` or `export PORT=<you-port-number>` The port number you want the integration to listen on (defaults to 5000)
  2. Source your bash profile

--- a/mattermost_giphy/app.py
+++ b/mattermost_giphy/app.py
@@ -45,7 +45,7 @@ def new_post():
         if not 'token' in data:
             raise Exception('Missing necessary token in the post data')
 
-        if MATTERMOST_GIPHY_TOKEN.find(data['token']) == -1:
+        if data['token'] not in MATTERMOST_GIPHY_TOKEN:
             raise Exception('Tokens did not match, it is possible that this request came from somewhere other than Mattermost')
 
         # NOTE: support the slash command

--- a/mattermost_giphy/settings.py
+++ b/mattermost_giphy/settings.py
@@ -16,5 +16,6 @@ SCHEME = os.environ.get('SCHEME', 'https')
 # the is a public beta key from giphy api
 GIPHY_API_KEY = os.environ.get('GIPHY_API_KEY', 'dc6zaTOxFJmzC')
 
-# the Mattemost token generated when you created your outgoing webhook
-MATTERMOST_GIPHY_TOKEN = os.environ.get('MATTERMOST_GIPHY_TOKEN', None)
+# the Mattermost token or tokens generated when you created your outgoing webhook
+# multiple tokens needs to be separated by a colon
+MATTERMOST_GIPHY_TOKEN = os.environ.get('MATTERMOST_GIPHY_TOKEN', '').split(':')


### PR DESCRIPTION
This is useful if you need to deploy giphy integration for multiple teams without running multiple Docker containers, machines or on different ports. By accepting more than one tokens you can run one instance for more than one teams.