### PR TITLE
Change .bash_profile to .profile

### DIFF
--- a/LINUX.md
+++ b/LINUX.md
@@ -28,7 +28,7 @@ Here's how to start:
  7. Copy the *Token* from your newly created slash command that appears under the *Existing commands* section
 
 3. **Run the server with the correct configuration**
- 1. Back on SSH or your terminal, add the following lines to your `~/.bash_profile`
+ 1. Back on SSH or your terminal, add the following lines to your `~/.profile`
     - `export MATTERMOST_GIPHY_TOKEN=<your-token-here>` This is the token you copied in the last section (you can specify multiple tokens which are separated by a colon)
     - `export MATTERMOST_GIPHY_HOST=<your-host>` or `export HOST=<your-host>` The host you want the integration (defaults to 0.0.0.0)
     - `export MATTERMOST_GIPHY_PORT=<your-port-number>` or `export PORT=<you-port-number>` The port number you want the integration to listen on (defaults to 5000)


### PR DESCRIPTION
Since this is the setup for Ubuntu (and not OSX), the standard bash config file is ~/.profile, not ~/.bash_profile